### PR TITLE
Add GFM-friendly line breaks and remove errant spaces.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Often, we find speaker lists or panels at conferences and other events that lack
 people from underrepresented groups. At times, we hear the excuse that there
 aren't enough people from underrepresented groups to reach out to or that they
 couldn't find any that wanted to participate.  This list aims to fix that
-problem. 
+problem.
 
 Everyone who wants to speak should consider adding themselves if you identify as part of an underrepresented group. Everyone's experiences matter and should be heard - no matter your skill level, title, role, etc. Please check out the [CONTRIBUTING.md](.github/CONTRIBUTING.md) file for guidelines for contributing.
 
@@ -20,15 +20,14 @@ DigitalOcean
 Ben Ilegbodu  
 Lead UI Engineer  
 Eventbrite  
-[Blog](http://www.benmvp.com) | [Twitter](https://twitter.com/benmvp) |
-[GitHub](https://github.com/benmvp)
+[Blog](http://www.benmvp.com) | [Twitter](https://twitter.com/benmvp) | [GitHub](https://github.com/benmvp)
 
 Juan Soto  
 Web Developer  
 [Website](http://juansoto.me) | [Twitter](https://twitter.com/_hooan) |
 [GitHub](https://github.com/sotojuan)
 
-Susan Lin   
+Susan Lin  
 Product Designer  
 [Website](http://bysusanlin.com) | [Twitter](https://twitter.com/bysusanlin) | [GitHub](https://github.com/bysl) | [Medium](https://medium.com/@bysusanlin)
 
@@ -49,7 +48,7 @@ Software Engineer
 [Github-personal](https://github.com/withtwoemms) |
 [Github-pro](https://github.com/emmanuellyautomated)
 
-Hardy Jones   
+Hardy Jones  
 Software Engineer  
 NoRedInk  
 [Website](http://joneshf.github.io/) | [Twitter](https://twitter.com/st58) |
@@ -84,7 +83,7 @@ Restive
 
 Alexander Miranda  
 Software Engineer  
-[Website](https://amiranda.me) | [Twitter](https://twitter.com/amiranda222) | [GitHub](https://github.com/ammiranda)  
+[Website](https://amiranda.me) | [Twitter](https://twitter.com/amiranda222) | [GitHub](https://github.com/ammiranda)
 
 Vaidehi Joshi  
 Software Engineer  
@@ -104,26 +103,26 @@ Product Manager and Facilitator
 Lauren Tan  
 Senior Full Stack Engineer  
 Netflix  
-[Website](http://www.sugarpirate.com) | [Twitter](https://twitter.com/sugarpirate_) | [GitHub](https://github.com/poteto) | [LinkedIn](https://www.linkedin.com/in/laurenelizabethtan)  
+[Website](http://www.sugarpirate.com) | [Twitter](https://twitter.com/sugarpirate_) | [GitHub](https://github.com/poteto) | [LinkedIn](https://www.linkedin.com/in/laurenelizabethtan)
 
 Lyn Muldrow  
 Technical Manager & Front-End Developer  
 Hack the Hood  
-[Website](http://lynmuldrow.com) | [Twitter](http://twitter.com/lynmuldrow) | [LinkedIn](http://linkedin.com/in/lynmuldrow)  
+[Website](http://lynmuldrow.com) | [Twitter](http://twitter.com/lynmuldrow) | [LinkedIn](http://linkedin.com/in/lynmuldrow)
 
 Gloria Kimbwala  
 Campus Technical Specialist  
 Square  
-[Twitter](https://twitter.com/gkimbwala) | [LinkedIn](https://linkedin.com/in/gkimbwala) | [GitHub](https://github.com/gkimbwala)  
+[Twitter](https://twitter.com/gkimbwala) | [LinkedIn](https://linkedin.com/in/gkimbwala) | [GitHub](https://github.com/gkimbwala)
 
 Patricia Realini  
 Software Engineer  
 Bustle  
-[Website](http://patriciarealini.com) | [Twitter](https://twitter.com/patriciarealini) | [GitHub](https://github.com/patriciarealini)  
+[Website](http://patriciarealini.com) | [Twitter](https://twitter.com/patriciarealini) | [GitHub](https://github.com/patriciarealini)
 
 Jacky Alciné  
 Software Engineer that Uses a Afropick as His Leader Key  
-[Website](https://jacky.wtf) | [Twitter](https://twitter.com/jackyalcine) | [Current Mood](http://black.af)  
+[Website](https://jacky.wtf) | [Twitter](https://twitter.com/jackyalcine) | [Current Mood](http://black.af)
 
 Michael Lancaster  
 Software Engineer  
@@ -133,8 +132,8 @@ Uptake
 
 Ron Bronson  
 Service Designer & UX Strategist  
-[Twitter] (http://twitter.com/ronbronson) | [Medium] (http://medium.com/@ronbronson) | 
-[Lanyrd] (http://lanyrd.com/profile/ronbronson/) | [Speakerdeck] (https://speakerdeck.com/ronbronson)
+[Twitter](http://twitter.com/ronbronson) | [Medium](http://medium.com/@ronbronson) |
+[Lanyrd](http://lanyrd.com/profile/ronbronson/) | [Speakerdeck](https://speakerdeck.com/ronbronson)
 
 Vasanth Krishnamoorthy  
 Sr. Front End Engineer  
@@ -148,8 +147,8 @@ https://www.usertesting.com
 [Website](http://blog.dudeblake.com/) | [Twitter](https://twitter.com/kblake) |
 [GitHub](https://github.com/kblake)
 
-Timothy B. Smith   
-Frontend Designer   
+Timothy B. Smith  
+Frontend Designer  
 [Website](https://ttimsmith.com) | [Twitter](https://twitter.com/smithtimmytim) | [GitHub](https://github.com/smithtimmytim) | [Blog](https://theboldreport.net)
 
 Taylor Barnett  
@@ -157,7 +156,7 @@ Developer Evangelist
 Keen IO  
 [Twitter](https://twitter.com/taylor_atx) | [Website](http://taylorbar.net/) | [GitHub](https://github.com/tbarn)
 
-Camille Emefa Acey   
+Camille Emefa Acey  
 VP Customer Success  
 Clubhouse  
 [Blog](http://medium.com/@kavbojka) | [Twitter](https://twitter.com/kavbojka)
@@ -239,8 +238,8 @@ Front End Web Developer
 
 Steve Lacy  
 Full-stack developer & Security researcher  
-Fact0ry / Independent   
-[Website](http://slacy.me) | [Twitter](https://twitter.com/stevedelacy) | 
+Fact0ry / Independent  
+[Website](http://slacy.me) | [Twitter](https://twitter.com/stevedelacy) |
 [Github](https://github.com/stevelacy)
 
 Atif Azam  
@@ -250,8 +249,8 @@ MongoDB
 [GitHub](http://www.github.com/atifazam)
 
 Irfan Ahmad  
-Lead QA Engineer   
-Upgrad.com   
+Lead QA Engineer  
+Upgrad.com  
 [Website](http://critick.io) | [Twitter](https://twitter.com/notimewaste) |
 [GitHub](https://github.com/irfanah)
 
@@ -260,7 +259,7 @@ UX Designer
 Booking.com  
 [Website](http://id.etc.br) | [Twitter](https://twitter.com/idmarjr) | [GitHub](https://github.com/idmarjr) | [Speaker Deck](https://speakerdeck.com/idmarjr)  
 
-Lovisa Svallingson   
+Lovisa Svallingson  
 Software Engineer  
 CA Technologies (Rally Software)  
 [Website](http://lovisa.io) | [Twitter](https://twitter.com/applegrain) | [GitHub](https://github.com/applegrain)
@@ -274,7 +273,7 @@ Marla Brizel
 Software Developer  
 Democracy Works  
 [Website](http://www.marlabrizel.com) | [Twitter](https://twitter.com/marlabrizel) |
-[GitHub](https://github.com/marlabrizel)  
+[GitHub](https://github.com/marlabrizel)
 
 Husani S. Oakley  
 Chief Technology Officer  
@@ -283,37 +282,37 @@ GoldBean
 [GitHub](https://github.com/husani) | [Linkedin](https://www.linkedin.com/in/husani)
 
 Stacey Haffner  
-Program Manager | Co-Founder/Developer   
+Program Manager | Co-Founder/Developer  
 Microsoft | What Up Games, LLC  
-[Twitter](https://twitter.com/yecats131) | [GitHub](https://github.com/staceyhaffner) | [Channel 9](https://channel9.msdn.com/Search?term=stacey%20haffner#ch9Search) | [Website](www.whatupgames.com)  
+[Twitter](https://twitter.com/yecats131) | [GitHub](https://github.com/staceyhaffner) | [Channel 9](https://channel9.msdn.com/Search?term=stacey%20haffner#ch9Search) | [Website](www.whatupgames.com)
 
 Jamie Chung  
 Engineer  
 Dropbox  
-[Website](http://jamiechu.ng) | [Twitter](https://twitter.com/attnjamie) | [GitHub](https://github.com/attnjamie) | [LinkedIn](https://www.linkedin.com/in/attnjamie)  
+[Website](http://jamiechu.ng) | [Twitter](https://twitter.com/attnjamie) | [GitHub](https://github.com/attnjamie) | [LinkedIn](https://www.linkedin.com/in/attnjamie)
 
-Mike McGarr
-Engineering Manager, Developer Productivity & Insight
-Netflix
+Mike McGarr  
+Engineering Manager, Developer Productivity & Insight  
+Netflix  
 [Website](http://www.mikemcgarr.com) | [Twitter](http://www.twitter.com/SonOfGarr) | [Github](https://github.com/jmcgarr) | [Slideshare](http://www.slideshare.net/jmcgarr/presentations)
 
 Princiya Marina Sequeira  
 Software Engineer FrontEnd  
 Zalando, Berlin  
-[Blog](https://princiya777.wordpress.com) | [Twitter](https://twitter.com/princi_ya) | [GitHub](https://github.com/princiya)  
+[Blog](https://princiya777.wordpress.com) | [Twitter](https://twitter.com/princi_ya) | [GitHub](https://github.com/princiya)
 
 Kim Crayton  
 Business Relationship Strategist  
 Kim Crayton LLC  
-[Website](http://KimCrayton.com) | [Website](http://JrDevMentoring.com) | [Twitter](https://twitter.com/KimCrayton1) | [Twitter](http://twitter.com/JrDevMentoring) | [Blog](https://medium.com/@KimCrayton1) | [Previous Presentations](https://www.youtube.com/playlist?list=PLEJ1RnaQ_swh7wiD80NSSLu8UrOv3DiQ6)  
+[Website](http://KimCrayton.com) | [Website](http://JrDevMentoring.com) | [Twitter](https://twitter.com/KimCrayton1) | [Twitter](http://twitter.com/JrDevMentoring) | [Blog](https://medium.com/@KimCrayton1) | [Previous Presentations](https://www.youtube.com/playlist?list=PLEJ1RnaQ_swh7wiD80NSSLu8UrOv3DiQ6)
 
 Courtney Wilburn  
 Back-End Developer/Programmer  
-[O3 World] (https://o3world.com) | [Website](https://portfolio.cjwilburn.com) | [Twitter](https://twitter.com/cjwilburn) | [GitHub](https://github.com/cjwilburn)
+[O3 World](https://o3world.com) | [Website](https://portfolio.cjwilburn.com) | [Twitter](https://twitter.com/cjwilburn) | [GitHub](https://github.com/cjwilburn)
 
-Sumana Harihareswara
-Founder, open source expert and maintainer
-Changeset Consulting
+Sumana Harihareswara  
+Founder, Open Source Expert and Maintainer  
+Changeset Consulting  
 [Website](https://www.changeset.nyc) | [Twitter](https://twitter.com/brainwane) | [GitHub](https://github.com/brainwane) | [Past talks](http://www.harihareswara.net/talks.html) | [Blog](http://www.harihareswara.net/ces.shtml)
 
 Zach Carter  
@@ -321,12 +320,12 @@ Founder & Design Engineer
 [Website](http://zaa.ch) | [Twitter](https://twitter.com/zii) |
 [GitHub](https://github.com/zaach) | [LinkedIn](http://linkedin.com/in/zachcarter)
 
-Anjuan Simmons   
-Technical Program Manager   
+Anjuan Simmons  
+Technical Program Manager  
 [Assemble Systems](http://assemblesystems.com/)  
-[Website](http://www.AnjuanSimmons.com) | [My Talks] (http://www.anjuansimmons.com/my-talks) | [Book Me] (http://www.anjuansimmons.com/book-me) | [Contact Me] (http://www.anjuansimmons.com/contact)    
+[Website](http://www.AnjuanSimmons.com) | [My Talks](http://www.anjuansimmons.com/my-talks) | [Book Me](http://www.anjuansimmons.com/book-me) | [Contact Me](http://www.anjuansimmons.com/contact)   
 [Twitter](https://twitter.com/anjuan) | [GitHub](https://github.com/anjuan) | [LinkedIn](http://linkedin.com/in/anjuan)
 
-Asia Hoe
-Product Designer
+Asia Hoe  
+Product Designer, 2U  
 [Website](http://asiahoe.com) | [Twitter](https://twitter.com/asiahoe) | [LinkedIn](https://linkedin.com/in/asiah) | [GitHub](https://github.com/asiahoe)


### PR DESCRIPTION
According to Atom, Markdown requires 2 spaces preceding the enter key to recognize the newline character. GitHub Flavored Markdown does not. Selecting the Break On Single Newline option for the [markdown-preview](https://github.com/atom/markdown-preview) plugin did not generate the appropriate line breaks on GitHub.

<img width="781" alt="screenshot 2016-10-17 16 26 32" src="https://cloud.githubusercontent.com/assets/5003835/19455586/8647d93c-948b-11e6-99e3-8f17f52c5f08.png">

Therefore, I manually added missing line breaks. I also cleaned up extraneous spaces.
